### PR TITLE
Composed Button

### DIFF
--- a/.github/workflows/ci-sample.yml
+++ b/.github/workflows/ci-sample.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Setup MAUI
       run: dotnet workload install maui ios android maccatalyst
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Setup MAUI
       run: dotnet workload install maui ios android maccatalyst
     - name: Build

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Setup MAUI
         run: dotnet workload install maui ios android maccatalyst
       - name: Pack

--- a/samples/Plugin.Maui.KeyListener.Sample/AppShell.xaml
+++ b/samples/Plugin.Maui.KeyListener.Sample/AppShell.xaml
@@ -8,6 +8,10 @@
 
     <ShellContent
         Title="Feature Plugin"
+        ContentTemplate="{DataTemplate pages:ComposedButton}" />
+
+    <ShellContent
+        Title="Feature Plugin"
         ContentTemplate="{DataTemplate pages:MainPage}" />
 
 </Shell>

--- a/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml
+++ b/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Plugin.Maui.KeyListener.Sample"
+             x:Class="Plugin.Maui.KeyListener.Sample.ComposedButton"
+             Title="ComposedButton">
+
+    <VerticalStackLayout Spacing="30">
+        <Entry Text="Platform Button">
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroupList>
+                    <VisualStateGroup Name="CommonStates">
+                        <VisualState Name="Normal">
+                        </VisualState>
+
+                        <VisualState Name="Focused">
+                            <VisualState.Setters>
+                                <Setter Property="FontSize" Value="36" />
+                                <Setter Property="Background" Value="Lime" />
+                            </VisualState.Setters>
+                        </VisualState>
+
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </VisualStateManager.VisualStateGroups>
+        </Entry>
+        <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30">
+            <Label 
+                Text="Tap Me"
+                TextColor="White"
+                VerticalOptions="Center" 
+                HorizontalOptions="Center" />
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroupList>
+                    <VisualStateGroup Name="CommonStates">
+                        <VisualState Name="Normal">
+                        </VisualState>
+
+                        <VisualState Name="Focused">
+                            <VisualState.Setters>
+                                <Setter Property="Background" Value="Red" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </VisualStateManager.VisualStateGroups>
+        </local:FocusableContentView>
+
+        <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30">
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroupList>
+                    <VisualStateGroup Name="CommonStates">
+                        <VisualState Name="Normal">
+                        </VisualState>
+
+                        <VisualState Name="Focused">
+                            <VisualState.Setters>
+                                <Setter Property="Background" Value="Red" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </VisualStateManager.VisualStateGroups>
+            <Label 
+                Text="Tap Me"
+                TextColor="White"
+                VerticalOptions="Center" 
+                HorizontalOptions="Center" />
+        </local:FocusableContentView>
+        <Entry Text="Platform Button"></Entry>
+    </VerticalStackLayout>
+</ContentPage>

--- a/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml
+++ b/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml
@@ -3,73 +3,78 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Plugin.Maui.KeyListener.Sample"
              x:Class="Plugin.Maui.KeyListener.Sample.ComposedButton"
+            xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              Title="ComposedButton">
+             
+    
+    <toolkit:SemanticOrderView x:Name="SemanticOrderView">
+        <VerticalStackLayout Spacing="30">
+            <Entry Text="Platform Button" x:Name="entry">
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroupList>
+                        <VisualStateGroup Name="CommonStates">
+                            <VisualState Name="Normal">
+                            </VisualState>
 
-    <VerticalStackLayout Spacing="30">
-        <Entry Text="Platform Button" x:Name="entry">
-            <VisualStateManager.VisualStateGroups>
-                <VisualStateGroupList>
-                    <VisualStateGroup Name="CommonStates">
-                        <VisualState Name="Normal">
-                        </VisualState>
+                            <VisualState Name="Focused">
+                                <VisualState.Setters>
+                                    <Setter Property="FontSize" Value="36" />
+                                    <Setter Property="Background" Value="Lime" />
+                                </VisualState.Setters>
+                            </VisualState>
 
-                        <VisualState Name="Focused">
-                            <VisualState.Setters>
-                                <Setter Property="FontSize" Value="36" />
-                                <Setter Property="Background" Value="Lime" />
-                            </VisualState.Setters>
-                        </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateGroupList>
+                </VisualStateManager.VisualStateGroups>
+            </Entry>
+            <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30" x:Name="FocusableContentView1" 
+                SemanticProperties.Description="Button 1">
+                <Label 
+                    Text="Tap Me"
+                    TextColor="White"
+                    VerticalOptions="Center" 
+                    HorizontalOptions="Center" />
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroupList>
+                        <VisualStateGroup Name="CommonStates">
+                            <VisualState Name="Normal">
+                            </VisualState>
 
-                    </VisualStateGroup>
-                </VisualStateGroupList>
-            </VisualStateManager.VisualStateGroups>
-        </Entry>
-        <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30" x:Name="FocusableContentView1" SemanticProperties.Description="Button 1">
-            <Label 
-                Text="Tap Me"
-                TextColor="White"
-                VerticalOptions="Center" 
-                HorizontalOptions="Center" />
-            <VisualStateManager.VisualStateGroups>
-                <VisualStateGroupList>
-                    <VisualStateGroup Name="CommonStates">
-                        <VisualState Name="Normal">
-                        </VisualState>
+                            <VisualState Name="Focused">
+                                <VisualState.Setters>
+                                    <Setter Property="Background" Value="Red" />
+                                </VisualState.Setters>
+                            </VisualState>
+                            
+                        </VisualStateGroup>
+                    </VisualStateGroupList>
+                </VisualStateManager.VisualStateGroups>
+            </local:FocusableContentView>
 
-                        <VisualState Name="Focused">
-                            <VisualState.Setters>
-                                <Setter Property="Background" Value="Red" />
-                            </VisualState.Setters>
-                        </VisualState>
-                        
-                    </VisualStateGroup>
-                </VisualStateGroupList>
-            </VisualStateManager.VisualStateGroups>
-        </local:FocusableContentView>
+            <local:FocusableContentView x:Name="FCW2" Background="Green" HorizontalOptions="Center" Padding="30" SemanticProperties.Description="Button 2">
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroupList>
+                        <VisualStateGroup Name="CommonStates">
+                            <VisualState Name="Normal">
+                            </VisualState>
 
-        <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30" SemanticProperties.Description="Button 2">
-            <VisualStateManager.VisualStateGroups>
-                <VisualStateGroupList>
-                    <VisualStateGroup Name="CommonStates">
-                        <VisualState Name="Normal">
-                        </VisualState>
-
-                        <VisualState Name="Focused">
-                            <VisualState.Setters>
-                                <Setter Property="Background" Value="Red" />
-                            </VisualState.Setters>
-                        </VisualState>
-                        
-                    </VisualStateGroup>
-                </VisualStateGroupList>
-            </VisualStateManager.VisualStateGroups>
-            <Label 
-                Text="Tap Me"
-                TextColor="White"
-                VerticalOptions="Center" 
-                HorizontalOptions="Center" />
-        </local:FocusableContentView>
-        <Entry Text="Platform Button"></Entry>
-        <Button Text="Focus one of the composite buttons" Clicked="Button_Clicked"></Button>
-    </VerticalStackLayout>
+                            <VisualState Name="Focused">
+                                <VisualState.Setters>
+                                    <Setter Property="Background" Value="Red" />
+                                </VisualState.Setters>
+                            </VisualState>
+                            
+                        </VisualStateGroup>
+                    </VisualStateGroupList>
+                </VisualStateManager.VisualStateGroups>
+                <Label 
+                    Text="Tap Me"
+                    TextColor="White"
+                    VerticalOptions="Center" 
+                    HorizontalOptions="Center" />
+            </local:FocusableContentView>
+            <Entry x:Name="entry1" Text="Platform Button"></Entry>
+            <Button x:Name="entry2" Text="Focus one of the composite buttons" Clicked="Button_Clicked"></Button>
+        </VerticalStackLayout>
+    </toolkit:SemanticOrderView>
 </ContentPage>

--- a/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml
+++ b/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml
@@ -24,7 +24,7 @@
                 </VisualStateGroupList>
             </VisualStateManager.VisualStateGroups>
         </Entry>
-        <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30" x:Name="FocusableContentView1">
+        <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30" x:Name="FocusableContentView1" SemanticProperties.Description="Button 1">
             <Label 
                 Text="Tap Me"
                 TextColor="White"
@@ -47,7 +47,7 @@
             </VisualStateManager.VisualStateGroups>
         </local:FocusableContentView>
 
-        <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30">
+        <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30" SemanticProperties.Description="Button 2">
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroupList>
                     <VisualStateGroup Name="CommonStates">

--- a/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml
+++ b/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml
@@ -6,7 +6,7 @@
              Title="ComposedButton">
 
     <VerticalStackLayout Spacing="30">
-        <Entry Text="Platform Button">
+        <Entry Text="Platform Button" x:Name="entry">
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroupList>
                     <VisualStateGroup Name="CommonStates">
@@ -24,7 +24,7 @@
                 </VisualStateGroupList>
             </VisualStateManager.VisualStateGroups>
         </Entry>
-        <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30">
+        <local:FocusableContentView Background="Green" HorizontalOptions="Center" Padding="30" x:Name="FocusableContentView1">
             <Label 
                 Text="Tap Me"
                 TextColor="White"
@@ -70,5 +70,6 @@
                 HorizontalOptions="Center" />
         </local:FocusableContentView>
         <Entry Text="Platform Button"></Entry>
+        <Button Text="Focus one of the composite buttons" Clicked="Button_Clicked"></Button>
     </VerticalStackLayout>
 </ContentPage>

--- a/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml.cs
@@ -1,0 +1,13 @@
+namespace Plugin.Maui.KeyListener.Sample;
+
+public partial class ComposedButton : ContentPage
+{
+	public ComposedButton()
+	{
+		InitializeComponent();
+	}
+
+	private void VerticalStackLayout_Focused(object sender, FocusEventArgs e)
+	{
+	}
+}

--- a/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml.cs
@@ -5,9 +5,23 @@ public partial class ComposedButton : ContentPage
 	public ComposedButton()
 	{
 		InitializeComponent();
+		FocusableContentView1.Focused += FocusableContentView1_Focused;
+		this.Loaded += ComposedButton_Loaded;
+		
 	}
 
-	private void VerticalStackLayout_Focused(object sender, FocusEventArgs e)
+	void ComposedButton_Loaded(object sender, EventArgs e)
 	{
+		FocusableContentView1.Focus();
+	}
+
+	void FocusableContentView1_Focused(object sender, FocusEventArgs e)
+	{
+			
+	}
+
+	void Button_Clicked(object sender, EventArgs e)
+	{
+		FocusableContentView1.Focus();
 	}
 }

--- a/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml.cs
@@ -5,19 +5,7 @@ public partial class ComposedButton : ContentPage
 	public ComposedButton()
 	{
 		InitializeComponent();
-		FocusableContentView1.Focused += FocusableContentView1_Focused;
-		this.Loaded += ComposedButton_Loaded;
 		
-	}
-
-	void ComposedButton_Loaded(object sender, EventArgs e)
-	{
-		FocusableContentView1.Focus();
-	}
-
-	void FocusableContentView1_Focused(object sender, FocusEventArgs e)
-	{
-			
 	}
 
 	void Button_Clicked(object sender, EventArgs e)

--- a/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/ComposedButton.xaml.cs
@@ -5,6 +5,7 @@ public partial class ComposedButton : ContentPage
 	public ComposedButton()
 	{
 		InitializeComponent();
+		this.SemanticOrderView.ViewOrder = new List<View> { entry, entry2,FocusableContentView1, FCW2, entry1 };
 		
 	}
 

--- a/samples/Plugin.Maui.KeyListener.Sample/FocusableContentView.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/FocusableContentView.cs
@@ -1,0 +1,23 @@
+using Microsoft.Maui.Controls;
+
+namespace Plugin.Maui.KeyListener.Sample;
+
+public class FocusableContentView : ContentView
+{
+    public FocusableContentView()
+    {
+        this.Focused += OnFocused;
+        this.GestureRecognizers.Add(new TapGestureRecognizer
+        {
+            NumberOfTapsRequired = 1,
+            Command = new Command(async () =>
+            {
+                await this.Window.Page.DisplayAlert("Tapped", "Tapped", "OK");
+            })
+        });
+    }
+
+	void OnFocused(object sender, FocusEventArgs e)
+	{
+	}
+}

--- a/samples/Plugin.Maui.KeyListener.Sample/FocusableContentViewPlatform.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/FocusableContentViewPlatform.cs
@@ -24,8 +24,25 @@ public class FocusableContentViewPlatform : Microsoft.Maui.Platform.ContentView/
 	// through keyboard settings then this view will be focusable if you set the Semantic properties
 	// If you set this to true, this will cause inconsistent behavior with native mac controls
 	// For example, a UIButton can't be reached by a keyboard unless you've enabled keyboard navigation
-	//public override bool CanBecomeFocused => true;
- 
+	public override bool CanBecomeFocused => true;
+	public override bool CanBecomeFirstResponder => true;
+
+	public override void PressesBegan(NSSet<UIPress> presses, UIPressesEvent evt)
+	{
+		base.PressesBegan(presses, evt);
+
+		/*
+		just testing out modifying tab ordering
+		foreach(var press in presses)
+		{
+			if (press.Key?.KeyCode == UIKeyboardHidUsage.KeyboardTab)
+			{
+				Superview.Subviews[0].BecomeFirstResponder();
+			}
+		}*/
+	}
+
+
 
 	public override void DidUpdateFocus(UIFocusUpdateContext context, UIFocusAnimationCoordinator coordinator)
     {

--- a/samples/Plugin.Maui.KeyListener.Sample/FocusableContentViewPlatform.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/FocusableContentViewPlatform.cs
@@ -14,13 +14,17 @@ public class FocusableContentViewPlatform : Microsoft.Maui.Platform.ContentView/
 
     public FocusableContentViewPlatform()
     {
-        //UserInteractionEnabled = true;
     }
 
-	public override bool CanBecomeFocused => true;
-	public override bool CanBecomeFirstResponder => true;
 
-    public override void DidUpdateFocus(UIFocusUpdateContext context, UIFocusAnimationCoordinator coordinator)
+	// You don't really need to override this, if the user has enabled basic Keyboard navigation
+	// through keyboard settings then this view will be focusable if you set the Semantic properties
+	// If you set this to true, this will cause inconsistent behavior with native mac controls
+	// For example, a UIButton can't be reached by a keyboard unless you've enabled keyboard navigation
+	//public override bool CanBecomeFocused => true;
+ 
+
+	public override void DidUpdateFocus(UIFocusUpdateContext context, UIFocusAnimationCoordinator coordinator)
     {
         base.DidUpdateFocus(context, coordinator);
 
@@ -28,7 +32,6 @@ public class FocusableContentViewPlatform : Microsoft.Maui.Platform.ContentView/
         {
 			if(CrossPlatformLayout is IView view)
 			{
-				//BecomeFirstResponder();
 				view.IsFocused = true;
 			}
 		}
@@ -36,45 +39,10 @@ public class FocusableContentViewPlatform : Microsoft.Maui.Platform.ContentView/
         {
 			if(CrossPlatformLayout is IView view)
 			{
-				//ResignFirstResponder();
 				view.IsFocused = false;
 			}
 		}
     }
-
-	public override void TouchesBegan(NSSet touches, UIEvent evt)
-    {
-        base.TouchesBegan(touches, evt);
-        // Ensure we become first responder when touched
-        if (!IsFirstResponder)
-		{
-			//BecomeFirstResponder();
-		}
-	}
-/*
-	 bool IUIKeyInput.HasText => false;
-    
-    async void IUIKeyInput.InsertText(string text)
-    {
-        if (text == "\n" || text == "\r")
-        {
-            if(CrossPlatformLayout is VisualElement view)
-			{
-				await view.Window?.Page?.DisplayAlert("Tapped", "Tapped", "OK");
-			}
-        }
-    }
-
-    void IUIKeyInput.DeleteBackward() { }
-	*/
-
-	/*public UITextAutocapitalizationType AutocapitalizationType => UITextAutocapitalizationType.None;
-    public UITextAutocorrectionType AutocorrectionType => UITextAutocorrectionType.No;
-    public UITextSpellCheckingType SpellCheckingType => UITextSpellCheckingType.No;
-    public UIKeyboardType KeyboardType => UIKeyboardType.Default;
-    public UIReturnKeyType ReturnKeyType => UIReturnKeyType.Default;
-    public bool EnablesReturnKeyAutomatically => false;
-    public bool SecureTextEntry => false;*/
 }
 
 #endif

--- a/samples/Plugin.Maui.KeyListener.Sample/FocusableContentViewPlatform.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/FocusableContentViewPlatform.cs
@@ -1,0 +1,80 @@
+#if IOS || MACCATALYST
+using System.Threading.Tasks;
+using Foundation;
+using Microsoft.Maui.Platform;
+using UIKit;
+
+namespace Plugin.Maui.KeyListener.Sample;
+
+/// <summary>
+/// The native implementation of the <see href="SemanticOrderView"/> control.
+/// </summary>
+public class FocusableContentViewPlatform : Microsoft.Maui.Platform.ContentView//, IUIKeyInput//, IUITextInputTraits
+{
+
+    public FocusableContentViewPlatform()
+    {
+        //UserInteractionEnabled = true;
+    }
+
+	public override bool CanBecomeFocused => true;
+	public override bool CanBecomeFirstResponder => true;
+
+    public override void DidUpdateFocus(UIFocusUpdateContext context, UIFocusAnimationCoordinator coordinator)
+    {
+        base.DidUpdateFocus(context, coordinator);
+
+        if (context.NextFocusedView == this)
+        {
+			if(CrossPlatformLayout is IView view)
+			{
+				//BecomeFirstResponder();
+				view.IsFocused = true;
+			}
+		}
+        else
+        {
+			if(CrossPlatformLayout is IView view)
+			{
+				//ResignFirstResponder();
+				view.IsFocused = false;
+			}
+		}
+    }
+
+	public override void TouchesBegan(NSSet touches, UIEvent evt)
+    {
+        base.TouchesBegan(touches, evt);
+        // Ensure we become first responder when touched
+        if (!IsFirstResponder)
+		{
+			//BecomeFirstResponder();
+		}
+	}
+/*
+	 bool IUIKeyInput.HasText => false;
+    
+    async void IUIKeyInput.InsertText(string text)
+    {
+        if (text == "\n" || text == "\r")
+        {
+            if(CrossPlatformLayout is VisualElement view)
+			{
+				await view.Window?.Page?.DisplayAlert("Tapped", "Tapped", "OK");
+			}
+        }
+    }
+
+    void IUIKeyInput.DeleteBackward() { }
+	*/
+
+	/*public UITextAutocapitalizationType AutocapitalizationType => UITextAutocapitalizationType.None;
+    public UITextAutocorrectionType AutocorrectionType => UITextAutocorrectionType.No;
+    public UITextSpellCheckingType SpellCheckingType => UITextSpellCheckingType.No;
+    public UIKeyboardType KeyboardType => UIKeyboardType.Default;
+    public UIReturnKeyType ReturnKeyType => UIReturnKeyType.Default;
+    public bool EnablesReturnKeyAutomatically => false;
+    public bool SecureTextEntry => false;*/
+}
+
+#endif

--- a/samples/Plugin.Maui.KeyListener.Sample/FocusableContentViewPlatform.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/FocusableContentViewPlatform.cs
@@ -1,5 +1,8 @@
 #if IOS || MACCATALYST
 using System.Threading.Tasks;
+using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Core.Views;
+using CommunityToolkit.Maui.Views;
 using Foundation;
 using Microsoft.Maui.Platform;
 using UIKit;
@@ -14,8 +17,8 @@ public class FocusableContentViewPlatform : Microsoft.Maui.Platform.ContentView/
 
     public FocusableContentViewPlatform()
     {
+		this.FocusGroupIdentifier = $"<{this.GetType().FullName}: {this.GetHashCode()}>";
     }
-
 
 	// You don't really need to override this, if the user has enabled basic Keyboard navigation
 	// through keyboard settings then this view will be focusable if you set the Semantic properties

--- a/samples/Plugin.Maui.KeyListener.Sample/FocusableContentViewPlatformHandler.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/FocusableContentViewPlatformHandler.cs
@@ -1,0 +1,21 @@
+#if IOS || MACCATALYST
+using Foundation;
+using Microsoft.Maui.Platform;
+using UIKit;
+
+
+namespace Plugin.Maui.KeyListener.Sample;
+
+public class FocusableContentViewPlatformHandler : Microsoft.Maui.Handlers.ContentViewHandler
+{
+	public FocusableContentViewPlatformHandler()
+	{
+	}
+
+	protected override Microsoft.Maui.Platform.ContentView CreatePlatformView()
+	{
+		return new FocusableContentViewPlatform();
+	}
+
+}
+#endif

--- a/samples/Plugin.Maui.KeyListener.Sample/MauiProgram.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/MauiProgram.cs
@@ -12,6 +12,12 @@ public static class MauiProgram
 		builder
 			.UseMauiApp<App>()
 			.UseKeyListener()
+			.ConfigureMauiHandlers(handlers =>
+			{
+				#if IOS || MACCATALYST
+				handlers.AddHandler(typeof(FocusableContentView), typeof(Plugin.Maui.KeyListener.Sample.FocusableContentViewPlatformHandler));
+				#endif
+			})
 			.ConfigureFonts(fonts =>
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/samples/Plugin.Maui.KeyListener.Sample/MauiProgram.cs
+++ b/samples/Plugin.Maui.KeyListener.Sample/MauiProgram.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Plugin.Maui.KeyListener;
 using Microsoft.Maui.Handlers;
+using CommunityToolkit.Maui;
+using CommunityToolkit.Maui.Core.Handlers;
+using CommunityToolkit.Maui.Views;
 
 namespace Plugin.Maui.KeyListener.Sample;
 
@@ -9,13 +12,33 @@ public static class MauiProgram
 	public static MauiApp CreateMauiApp()
 	{
 		var builder = MauiApp.CreateBuilder();
+
 		builder
 			.UseMauiApp<App>()
 			.UseKeyListener()
+			.UseMauiCommunityToolkit()
 			.ConfigureMauiHandlers(handlers =>
 			{
 				#if IOS || MACCATALYST
 				handlers.AddHandler(typeof(FocusableContentView), typeof(Plugin.Maui.KeyListener.Sample.FocusableContentViewPlatformHandler));
+
+				/*SemanticOrderViewHandler.PlatformViewFactory = (handler) =>
+				{
+					if (handler.VirtualView is not SemanticOrderView)
+					{
+						return null;
+					}
+
+					var vc = new MauiSemanticOrderView2ViewController();
+					var view = vc.View as MauiSemanticOrderView2;
+					view.VirtualView2 = handler.VirtualView as SemanticOrderView;
+
+					((Shell.Current.CurrentPage as ContentPage).Handler as IPlatformViewHandler)
+						.ViewController?.AddChildViewController(vc);
+
+					return view;
+				};*/
+
 				#endif
 			})
 			.ConfigureFonts(fonts =>

--- a/samples/Plugin.Maui.KeyListener.Sample/Plugin.Maui.KeyListener.Sample.csproj
+++ b/samples/Plugin.Maui.KeyListener.Sample/Plugin.Maui.KeyListener.Sample.csproj
@@ -29,6 +29,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+		<MauiVersion>9.0.50</MauiVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -47,5 +48,6 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Plugin.Maui.KeyListener\Plugin.Maui.KeyListener.csproj" />
+	  <PackageReference Include="CommunityToolkit.Maui" Version="11.2.0" />
 	</ItemGroup>
 </Project>

--- a/samples/Plugin.Maui.KeyListener.Sample/Plugin.Maui.KeyListener.Sample.csproj
+++ b/samples/Plugin.Maui.KeyListener.Sample/Plugin.Maui.KeyListener.Sample.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
@@ -24,7 +24,7 @@
 		<ApplicationVersion>1</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>

--- a/src/Plugin.Maui.KeyListener/MauiProgramExtension.cs
+++ b/src/Plugin.Maui.KeyListener/MauiProgramExtension.cs
@@ -11,6 +11,9 @@ public static class MauiProgramExtensions
 			#if IOS || MACCATALYST
 				PageHandler.PlatformViewFactory = (handler) =>
 				{
+					if (handler is not PageHandler pageHandler)
+						return null;
+						
 					var vc = new KeyboardPageViewController(handler.VirtualView, handler.MauiContext);
 					handler.ViewController = vc;
 					return (Microsoft.Maui.Platform.ContentView)vc.View.Subviews[0];

--- a/src/Plugin.Maui.KeyListener/Plugin.Maui.KeyListener.csproj
+++ b/src/Plugin.Maui.KeyListener/Plugin.Maui.KeyListener.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0</TargetFrameworks>
-   		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0</TargetFrameworks>
+   		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -12,7 +12,7 @@
 		<SkipValidateMauiImplicitPackageReferences>true</SkipValidateMauiImplicitPackageReferences>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
@@ -65,7 +65,7 @@
 	</ItemGroup>
 	<!-- .NET (generic) -->
 	<ItemGroup Condition="!($(TargetFramework.StartsWith('net')) == true AND $(TargetFramework.EndsWith('.0')) == true AND $(TargetFramework.Contains('-')) != true)">
-		<!-- e.g net6.0 or net8.0 (and higher) -->
+		<!-- e.g net6.0 or net9.0 (and higher) -->
 		<Compile Remove="**\*.net.cs" />
 		<None Include="**\*.net.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
 	</ItemGroup>


### PR DESCRIPTION
### Description

Current observations with regards to creating a Composite Button out of a "Content View" that works with keyboard

1) Currently MAUI doesn't propagate `Focus` changes from a basic `MauiView` up to the xplat code. I've created an issue [here](https://github.com/dotnet/maui/issues/28945) so that if focus behavior has been enabled then you can use a VSM for style changes. I've hacked around this in this PR for now to demonstrate the behavior 

2) Generally a `Content View` works fine for keyboard navigation if you've setup the expectations correctly. If you add a `SemanticDescription` to a contentview this causes it to become part of the accessibility tree. This means that if you enable basic keyboard enhancement features on MAC you'll be able to navigate to the `Content View` with a keyboard. 

As a note, this is also how `UIButton` works. 

If you build a basic swift app, you won't be able to navigate to this button.

![image](https://github.com/user-attachments/assets/294b0b5e-6f6c-424e-8a1d-2c598d8de0d1)

Once you enable Keyboard Navigation in the Keyboard Settings on your mac  (Settings => Keyboard => Keyboard SEttings => Keyboard Navigation) then it works fine. 

3) If you want to be able to navigate to the `ContentView` without enabling Keyboard Navigation you can override the "CanBecomeFocused" property on the `ContentView` and return true. This is not really recommended though because other interactive controls aren't going to work like this either. For example, any native control (UIButton) will still be unreachable with a keyboard unless you enable keyboard navigation.
