### PR TITLE
Make KeyChar upper case on Android

### DIFF
--- a/src/Plugin.Maui.KeyListener/KeyboardBehavior.Android.cs
+++ b/src/Plugin.Maui.KeyListener/KeyboardBehavior.Android.cs
@@ -55,7 +55,7 @@ public partial class KeyboardBehavior : PlatformBehavior<VisualElement>
 		{
 			Keys = @event.KeyCode.ToKeyboardKeys(),
 			Modifiers = KeyboardModifiersExtensions.ToKeyboardModifiers(@event.MetaState),
-			KeyChar = (char)@event.UnicodeChar
+			KeyChar = char.ToUpper((char)@event.UnicodeChar)
 		};
 
 		switch (@event.Action)


### PR DESCRIPTION
Match the behavior of other platforms